### PR TITLE
feat: Improve error handling in `D2Wrapper`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,36 @@ var svg = wrapper.RenderDiagram(script);
 // You can save this to a file, display it in a web page, or process it further as needed
 ```
 
+## Error Handling
+
+The `RenderDiagram` method now returns a `RenderResult` object, which includes both the rendered SVG (if successful) and detailed error information (if rendering failed). Here's how you can use it:
+
+```csharp
+var wrapper = new D2Wrapper();
+string script = @"
+A -> B
+B ->  // This line has an error
+C -> D
+";
+
+var result = wrapper.RenderDiagram(script);
+
+if (result.IsSuccess)
+{
+    Console.WriteLine("Diagram rendered successfully:");
+    Console.WriteLine(result.Svg);
+}
+else
+{
+    Console.WriteLine("Error rendering diagram:");
+    Console.WriteLine($"Message: {result.Error.Message}");
+    if (result.Error.LineNumber.HasValue)
+    {
+        Console.WriteLine($"Line {result.Error.LineNumber}: {result.Error.LineContent}");
+    }
+}
+```
+
 Running the web demo:
 
 ```

--- a/README.nuget.md
+++ b/README.nuget.md
@@ -49,6 +49,36 @@ catch (Exception ex)
 }
 ```
 
+## Error Handling
+
+The `RenderDiagram` method now returns a `RenderResult` object, which includes both the rendered SVG (if successful) and detailed error information (if rendering failed). Here's how you can use it:
+
+```csharp
+var wrapper = new D2Wrapper();
+string script = @"
+A -> B
+B ->  // This line has an error
+C -> D
+";
+
+var result = wrapper.RenderDiagram(script);
+
+if (result.IsSuccess)
+{
+    Console.WriteLine("Diagram rendered successfully:");
+    Console.WriteLine(result.Svg);
+}
+else
+{
+    Console.WriteLine("Error rendering diagram:");
+    Console.WriteLine($"Message: {result.Error.Message}");
+    if (result.Error.LineNumber.HasValue)
+    {
+        Console.WriteLine($"Line {result.Error.LineNumber}: {result.Error.LineContent}");
+    }
+}
+```
+
 ## Features
 
 - Render D2 diagrams as SVG

--- a/examples/D2Sharp.Web/wwwroot/index.html
+++ b/examples/D2Sharp.Web/wwwroot/index.html
@@ -8,12 +8,16 @@
         body { font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }
         textarea { width: 100%; height: 200px; }
         #result { margin-top: 20px; }
+        .error { color: red; }
+        .error-line { font-family: monospace; white-space: pre; background-color: #ffeeee; padding: 5px; border-radius: 3px; }
+        .error-highlight { background-color: #ff6666; color: white; font-weight: bold; }
     </style>
 </head>
 <body>
     <h1>D2Sharp Web Demo</h1>
     <textarea id="script" placeholder="Enter your D2 script here...">direction: right
-A -> B -> C</textarea>
+A -> B ->
+C -> D</textarea>
     <button onclick="renderDiagram()">Render Diagram</button>
     <div id="result"></div>
 
@@ -33,11 +37,16 @@ A -> B -> C</textarea>
                     const svg = await response.text();
                     result.innerHTML = svg;
                 } else {
-                    const error = await response.text();
-                    result.textContent = `Error: ${error}`;
+                    const error = await response.json();
+                    let errorMessage = `<p class="error">Error: ${error.message}</p>`;
+                    if (error.lineNumber && error.column) {
+                        errorMessage += `<p class="error">At line ${error.lineNumber}, column ${error.column}:</p>`;
+                        errorMessage += `<div class="error-line">${error.highlightedLineParts.beforeError}<span class="error-highlight">${error.highlightedLineParts.errorPart}</span>${error.highlightedLineParts.afterError}</div>`;
+                    }
+                    result.innerHTML = errorMessage;
                 }
             } catch (error) {
-                result.textContent = `Error: ${error.message}`;
+                result.innerHTML = `<p class="error">Error: ${error.message}</p>`;
             }
         }
     </script>

--- a/src/D2Sharp/D2Wrapper.cs
+++ b/src/D2Sharp/D2Wrapper.cs
@@ -1,6 +1,7 @@
 ﻿using System.Runtime.InteropServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Text.RegularExpressions;
 
 namespace D2Sharp;
 
@@ -19,9 +20,10 @@ public partial class D2Wrapper
     [LibraryImport("d2wrapper", EntryPoint = "FreeDiagram")]
     private static partial void FreeDiagram(IntPtr ptr);
 
-    public string? RenderDiagram(string script)
+    public RenderResult RenderDiagram(string script)
     {
-        _logger.LogDebug("Calling RenderDiagram with script {Script}", script);
+        _logger.LogDebug("Calling RenderDiagram with script");
+
         IntPtr errorPtr;
         var svgPtr = RenderDiagramInternal(script, out errorPtr);
 
@@ -30,19 +32,87 @@ public partial class D2Wrapper
             var errorMessage = Marshal.PtrToStringUTF8(errorPtr);
             FreeDiagram(errorPtr);
             _logger.LogError("Diagram rendering failed: {ErrorMessage}", errorMessage);
-            throw new Exception($"Diagram rendering failed: {errorMessage}");
+            return new RenderResult { Error = ParseError(errorMessage, script) };
         }
 
         if (svgPtr == IntPtr.Zero)
         {
             _logger.LogError("RenderDiagramInternal returned null pointer");
-            return null;
+            return new RenderResult { Error = new D2Error { Message = "Rendering failed with null result" } };
         }
 
         var svg = Marshal.PtrToStringUTF8(svgPtr);
         FreeDiagram(svgPtr);
 
-        _logger.LogDebug("Rendered diagram");
-        return svg;
+        _logger.LogDebug("Rendered diagram successfully");
+        return new RenderResult { Svg = svg };
+    }
+
+    private D2Error ParseError(string errorMessage, string script)
+    {
+        var error = new D2Error { Message = errorMessage };
+
+        // Match the format: "Compilation error: line:column: specific error message"
+        var match = Regex.Match(errorMessage, @"Compilation error: (\d+):(\d+): (.+)");
+        if (match.Success)
+        {
+            if (int.TryParse(match.Groups[1].Value, out int lineNumber))
+            {
+                error.LineNumber = lineNumber;
+                error.LineContent = GetLineContent(script, lineNumber);
+            }
+            if (int.TryParse(match.Groups[2].Value, out int column))
+            {
+                error.Column = column;
+            }
+            error.Message = match.Groups[3].Value.Trim();
+        }
+
+        return error;
+    }
+
+    private string GetLineContent(string script, int lineNumber)
+    {
+        var lines = script.Split('\n');
+        if (lineNumber > 0 && lineNumber <= lines.Length)
+        {
+            return lines[lineNumber - 1];
+        }
+        return string.Empty;
+    }
+}
+
+public class RenderResult
+{
+    public string? Svg { get; set; }
+    public D2Error? Error { get; set; }
+    public bool IsSuccess => Error == null;
+}
+
+public class D2Error
+{
+    public string Message { get; set; } = "";
+    public int? LineNumber { get; set; }
+    public int? Column { get; set; }
+    public string? LineContent { get; set; }
+
+    public (string beforeError, string errorPart, string afterError) GetHighlightedLineParts()
+    {
+        if (string.IsNullOrEmpty(LineContent) || !Column.HasValue || Column.Value <= 0)
+        {
+            return (LineContent ?? "", "", "");
+        }
+
+        int highlightIndex = Column.Value - 1;
+        if (highlightIndex >= LineContent.Length)
+        {
+            highlightIndex = LineContent.Length - 1;
+        }
+
+        string beforeError = LineContent.Substring(0, highlightIndex);
+        string errorPart = LineContent.Substring(highlightIndex, 1);
+        string afterError = highlightIndex + 1 < LineContent.Length ? LineContent.Substring(highlightIndex + 1) : "";
+
+        return (beforeError, errorPart, afterError);
     }
 }


### PR DESCRIPTION
This PR improves error handling in `D2Wrapper` and updates the web demo accordingly:

1. Added `RenderResult` class to return either SVG or error info.
2. Implemented detailed error parsing (line numbers, columns, messages).
3. Updated web demo to display errors with highlighting.
4. Added error handling examples to README.
5. Refactored web demo to use new error reporting features.

These changes aim to provide clearer error information, making D2 script debugging easier.