### PR TITLE
fix: Native library not copied to dependent projects on Windows

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,7 +27,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_D2SharpWorkerFiles Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker" />
+      <!-- Worker launcher only exists on Linux/macOS, not Windows -->
+      <_D2SharpWorkerFiles Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker"
+                           Condition="Exists('$(_D2SharpWorkerSourcePath)D2Sharp.Worker')" />
       <_D2SharpWorkerFiles Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker.dll" />
       <_D2SharpWorkerFiles Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker.deps.json" />
       <_D2SharpWorkerFiles Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker.runtimeconfig.json" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!--
+    This Directory.Build.targets file is automatically imported by MSBuild into ALL projects in the solution.
+    It ensures D2Sharp.Worker is built before any consuming project builds (e.g., D2Sharp.Web, tests, benchmarks).
+
+    This solves the "Worker files missing after dotnet clean" issue when using F5 debug in VS Code,
+    which builds individual projects rather than the whole solution.
+  -->
+
+  <!-- Build Worker if it's missing and we're not building D2Sharp or Worker itself -->
+  <Target Name="EnsureD2SharpWorkerIsBuilt"
+          BeforeTargets="BeforeBuild"
+          Condition="'$(MSBuildProjectName)' != 'D2Sharp' AND '$(MSBuildProjectName)' != 'D2Sharp.Worker' AND Exists('$(MSBuildThisFileDirectory)src/D2Sharp.Worker/D2Sharp.Worker.csproj') AND !Exists('$(MSBuildThisFileDirectory)src/D2Sharp.Worker/bin/$(Configuration)/net8.0/D2Sharp.Worker.dll')">
+    <Message Text="D2Sharp.Worker not found - building it now to enable process isolation..." Importance="high" />
+    <MSBuild Projects="$(MSBuildThisFileDirectory)src/D2Sharp.Worker/D2Sharp.Worker.csproj"
+             Properties="Configuration=$(Configuration)"
+             Targets="Build" />
+  </Target>
+
+  <!-- Copy Worker files to consuming projects (not D2Sharp or Worker itself) -->
+  <Target Name="CopyD2SharpWorkerFiles"
+          AfterTargets="Build"
+          Condition="'$(MSBuildProjectName)' != 'D2Sharp' AND '$(MSBuildProjectName)' != 'D2Sharp.Worker' AND Exists('$(MSBuildThisFileDirectory)src/D2Sharp.Worker/bin/$(Configuration)/net8.0/D2Sharp.Worker.dll')">
+    <PropertyGroup>
+      <_D2SharpWorkerSourcePath>$(MSBuildThisFileDirectory)src/D2Sharp.Worker/bin/$(Configuration)/net8.0/</_D2SharpWorkerSourcePath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_D2SharpWorkerFiles Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker" />
+      <_D2SharpWorkerFiles Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker.dll" />
+      <_D2SharpWorkerFiles Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker.deps.json" />
+      <_D2SharpWorkerFiles Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker.runtimeconfig.json" />
+      <_D2SharpWorkerFiles Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker.pdb" />
+      <_D2SharpWorkerFiles Include="$(_D2SharpWorkerSourcePath)Microsoft.Extensions.*.dll" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_D2SharpWorkerFiles)"
+          DestinationFolder="$(OutputPath)"
+          SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/src/D2Sharp/D2Sharp.csproj
+++ b/src/D2Sharp/D2Sharp.csproj
@@ -75,14 +75,19 @@
         <NativeLibName>d2wrapper$(NativeLibExtension)</NativeLibName>
     </PropertyGroup>
 
-    <ItemGroup>
-        <None Include="$(OutputPath)\$(NativeLibName)" Link="$(NativeLibName)">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Pack>true</Pack>
-            <PackagePath>lib/net8.0</PackagePath>
-            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        </None>
-    </ItemGroup>
+    <!-- Include native library dynamically after it's built -->
+    <Target Name="IncludeNativeLibrary" AfterTargets="BuildD2Wrapper" BeforeTargets="BeforeBuild">
+        <ItemGroup>
+            <Content Include="$(OutputPath)$(NativeLibName)">
+                <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+                <Pack>true</Pack>
+                <PackagePath>lib/net8.0</PackagePath>
+                <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+                <Link>$(NativeLibName)</Link>
+                <Visible>false</Visible>
+            </Content>
+        </ItemGroup>
+    </Target>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"/>

--- a/src/D2Sharp/D2Sharp.csproj
+++ b/src/D2Sharp/D2Sharp.csproj
@@ -97,59 +97,25 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     </ItemGroup>
 
-    <!-- Reference Worker files directly from Worker's output directory -->
-    <!-- This avoids circular dependencies and ensures files are propagated to consuming projects -->
-    <!-- Worker must be built as part of solution build before D2Sharp -->
-    <PropertyGroup>
-        <_WorkerSourcePath>$(MSBuildThisFileDirectory)../D2Sharp.Worker/bin/$(Configuration)/net8.0/</_WorkerSourcePath>
-    </PropertyGroup>
+    <!-- Import D2Sharp.targets for local development with project references -->
+    <!-- This same file is also packaged and auto-imported by NuGet for package consumers -->
+    <Import Project="D2Sharp.targets" />
 
+    <!-- Package the .targets file and Worker files for NuGet -->
     <ItemGroup>
-        <!-- Core Worker executable and runtime files -->
-        <Content Include="$(_WorkerSourcePath)D2Sharp.Worker" Condition="Exists('$(_WorkerSourcePath)D2Sharp.Worker')">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Link>D2Sharp.Worker</Link>
-            <Visible>false</Visible>
-            <Pack>true</Pack>
-            <PackagePath>lib/net8.0</PackagePath>
-        </Content>
-        <Content Include="$(_WorkerSourcePath)D2Sharp.Worker.dll" Condition="Exists('$(_WorkerSourcePath)D2Sharp.Worker.dll')">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Link>D2Sharp.Worker.dll</Link>
-            <Visible>false</Visible>
-            <Pack>true</Pack>
-            <PackagePath>lib/net8.0</PackagePath>
-        </Content>
-        <Content Include="$(_WorkerSourcePath)D2Sharp.Worker.deps.json" Condition="Exists('$(_WorkerSourcePath)D2Sharp.Worker.deps.json')">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Link>D2Sharp.Worker.deps.json</Link>
-            <Visible>false</Visible>
-            <Pack>true</Pack>
-            <PackagePath>lib/net8.0</PackagePath>
-        </Content>
-        <Content Include="$(_WorkerSourcePath)D2Sharp.Worker.runtimeconfig.json" Condition="Exists('$(_WorkerSourcePath)D2Sharp.Worker.runtimeconfig.json')">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Link>D2Sharp.Worker.runtimeconfig.json</Link>
-            <Visible>false</Visible>
-            <Pack>true</Pack>
-            <PackagePath>lib/net8.0</PackagePath>
-        </Content>
-        <Content Include="$(_WorkerSourcePath)D2Sharp.Worker.pdb" Condition="Exists('$(_WorkerSourcePath)D2Sharp.Worker.pdb')">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Link>D2Sharp.Worker.pdb</Link>
-            <Visible>false</Visible>
-            <Pack>true</Pack>
-            <PackagePath>lib/net8.0</PackagePath>
-        </Content>
+        <!-- Include .targets file in build/ folder so NuGet auto-imports it -->
+        <None Include="D2Sharp.targets" Pack="true" PackagePath="build/D2Sharp.targets" />
 
-        <!-- Worker dependencies that may not be in consuming project's framework -->
-        <Content Include="$(_WorkerSourcePath)Microsoft.Extensions.*.dll">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Link>%(Filename)%(Extension)</Link>
-            <Visible>false</Visible>
-            <Pack>true</Pack>
-            <PackagePath>lib/net8.0</PackagePath>
-        </Content>
+        <!-- Include Worker files in build/ folder so .targets can reference them -->
+        <None Include="$(MSBuildThisFileDirectory)../D2Sharp.Worker/bin/$(Configuration)/net8.0/D2Sharp.Worker*"
+              Pack="true"
+              PackagePath="build/D2Sharp.Worker"
+              Condition="Exists('$(MSBuildThisFileDirectory)../D2Sharp.Worker/bin/$(Configuration)/net8.0/D2Sharp.Worker')" />
+
+        <None Include="$(MSBuildThisFileDirectory)../D2Sharp.Worker/bin/$(Configuration)/net8.0/Microsoft.Extensions.*.dll"
+              Pack="true"
+              PackagePath="build/D2Sharp.Worker"
+              Condition="Exists('$(MSBuildThisFileDirectory)../D2Sharp.Worker/bin/$(Configuration)/net8.0')" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/D2Sharp/D2Sharp.csproj
+++ b/src/D2Sharp/D2Sharp.csproj
@@ -97,28 +97,59 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     </ItemGroup>
 
-    <!-- Copy worker executable to output directory (process isolation) -->
-    <!-- IMPORTANT: Worker runs as standalone process, so needs all dependencies even if consuming project has them in framework -->
-    <Target Name="CopyWorkerExecutable" AfterTargets="Build">
-        <!-- Ensure Worker is restored and built before copying (avoids circular reference by using MSBuild task instead of ProjectReference) -->
-        <MSBuild Projects="$(MSBuildThisFileDirectory)../D2Sharp.Worker/D2Sharp.Worker.csproj"
-                 Targets="Restore;Build"
-                 Properties="Configuration=$(Configuration)" />
-        <ItemGroup>
-            <WorkerFiles Include="$(MSBuildThisFileDirectory)../D2Sharp.Worker/bin/$(Configuration)/net8.0/**/*.*"/>
-        </ItemGroup>
-        <!-- Copy all worker files, forcing overwrite to ensure ASP.NET Core apps get framework dependencies -->
-        <Copy SourceFiles="@(WorkerFiles)" DestinationFolder="$(OutputPath)%(RecursiveDir)" OverwriteReadOnlyFiles="true" Condition="'@(WorkerFiles)' != ''" />
-        <Warning Text="D2Sharp.Worker not found at $(MSBuildThisFileDirectory)../D2Sharp.Worker/bin/$(Configuration)/net8.0/. Process isolation will not be available. Build the solution to include the worker." Condition="'@(WorkerFiles)' == ''" />
-    </Target>
+    <!-- Reference Worker files directly from Worker's output directory -->
+    <!-- This avoids circular dependencies and ensures files are propagated to consuming projects -->
+    <!-- Worker must be built as part of solution build before D2Sharp -->
+    <PropertyGroup>
+        <_WorkerSourcePath>$(MSBuildThisFileDirectory)../D2Sharp.Worker/bin/$(Configuration)/net8.0/</_WorkerSourcePath>
+    </PropertyGroup>
 
-    <!-- Include worker files as content so they're copied to consuming projects -->
     <ItemGroup>
-        <None Include="$(OutputPath)D2Sharp.Worker*" CopyToOutputDirectory="PreserveNewest" Link="%(Filename)%(Extension)" Visible="false">
+        <!-- Core Worker executable and runtime files -->
+        <Content Include="$(_WorkerSourcePath)D2Sharp.Worker" Condition="Exists('$(_WorkerSourcePath)D2Sharp.Worker')">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <Link>D2Sharp.Worker</Link>
+            <Visible>false</Visible>
             <Pack>true</Pack>
             <PackagePath>lib/net8.0</PackagePath>
-            <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        </None>
+        </Content>
+        <Content Include="$(_WorkerSourcePath)D2Sharp.Worker.dll" Condition="Exists('$(_WorkerSourcePath)D2Sharp.Worker.dll')">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <Link>D2Sharp.Worker.dll</Link>
+            <Visible>false</Visible>
+            <Pack>true</Pack>
+            <PackagePath>lib/net8.0</PackagePath>
+        </Content>
+        <Content Include="$(_WorkerSourcePath)D2Sharp.Worker.deps.json" Condition="Exists('$(_WorkerSourcePath)D2Sharp.Worker.deps.json')">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <Link>D2Sharp.Worker.deps.json</Link>
+            <Visible>false</Visible>
+            <Pack>true</Pack>
+            <PackagePath>lib/net8.0</PackagePath>
+        </Content>
+        <Content Include="$(_WorkerSourcePath)D2Sharp.Worker.runtimeconfig.json" Condition="Exists('$(_WorkerSourcePath)D2Sharp.Worker.runtimeconfig.json')">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <Link>D2Sharp.Worker.runtimeconfig.json</Link>
+            <Visible>false</Visible>
+            <Pack>true</Pack>
+            <PackagePath>lib/net8.0</PackagePath>
+        </Content>
+        <Content Include="$(_WorkerSourcePath)D2Sharp.Worker.pdb" Condition="Exists('$(_WorkerSourcePath)D2Sharp.Worker.pdb')">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <Link>D2Sharp.Worker.pdb</Link>
+            <Visible>false</Visible>
+            <Pack>true</Pack>
+            <PackagePath>lib/net8.0</PackagePath>
+        </Content>
+
+        <!-- Worker dependencies that may not be in consuming project's framework -->
+        <Content Include="$(_WorkerSourcePath)Microsoft.Extensions.*.dll">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <Link>%(Filename)%(Extension)</Link>
+            <Visible>false</Visible>
+            <Pack>true</Pack>
+            <PackagePath>lib/net8.0</PackagePath>
+        </Content>
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/D2Sharp/D2Sharp.csproj
+++ b/src/D2Sharp/D2Sharp.csproj
@@ -97,6 +97,7 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     </ItemGroup>
 
+
     <!-- Import D2Sharp.targets for local development with project references -->
     <!-- This same file is also packaged and auto-imported by NuGet for package consumers -->
     <Import Project="D2Sharp.targets" />

--- a/src/D2Sharp/D2Sharp.targets
+++ b/src/D2Sharp/D2Sharp.targets
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!--
+    This targets file is automatically imported by NuGet into consuming projects.
+    It copies D2Sharp.Worker files from the package to the consuming project's output directory.
+
+    For local development with project references, this file is also imported by D2Sharp.csproj.
+  -->
+
+  <PropertyGroup>
+    <!-- Locate Worker files based on context -->
+    <!-- For project references: D2Sharp.targets is in src/D2Sharp/, Worker is in src/D2Sharp.Worker/bin/... -->
+    <!-- For NuGet package: Worker files are in build/D2Sharp.Worker/ -->
+    <_D2SharpWorkerSourcePath Condition="Exists('$(MSBuildThisFileDirectory)../D2Sharp.Worker/bin/$(Configuration)/net8.0/D2Sharp.Worker')">$(MSBuildThisFileDirectory)../D2Sharp.Worker/bin/$(Configuration)/net8.0/</_D2SharpWorkerSourcePath>
+    <_D2SharpWorkerSourcePath Condition="'$(_D2SharpWorkerSourcePath)' == '' AND Exists('$(MSBuildThisFileDirectory)D2Sharp.Worker/D2Sharp.Worker')">$(MSBuildThisFileDirectory)D2Sharp.Worker/</_D2SharpWorkerSourcePath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Core Worker executable and runtime files -->
+    <Content Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker" Condition="Exists('$(_D2SharpWorkerSourcePath)D2Sharp.Worker')">
+      <Link>D2Sharp.Worker</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+
+    <Content Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker.dll" Condition="Exists('$(_D2SharpWorkerSourcePath)D2Sharp.Worker.dll')">
+      <Link>D2Sharp.Worker.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+
+    <Content Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker.deps.json" Condition="Exists('$(_D2SharpWorkerSourcePath)D2Sharp.Worker.deps.json')">
+      <Link>D2Sharp.Worker.deps.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+
+    <Content Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker.runtimeconfig.json" Condition="Exists('$(_D2SharpWorkerSourcePath)D2Sharp.Worker.runtimeconfig.json')">
+      <Link>D2Sharp.Worker.runtimeconfig.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+
+    <Content Include="$(_D2SharpWorkerSourcePath)D2Sharp.Worker.pdb" Condition="Exists('$(_D2SharpWorkerSourcePath)D2Sharp.Worker.pdb')">
+      <Link>D2Sharp.Worker.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+
+    <!-- Worker dependencies that might not be in consuming project's framework -->
+    <Content Include="$(_D2SharpWorkerSourcePath)Microsoft.Extensions.*.dll">
+      <Link>%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>false</Visible>
+    </Content>
+  </ItemGroup>
+
+  <!-- Warn if Worker files are missing (e.g., after dotnet clean with project references) -->
+  <Target Name="WarnIfD2SharpWorkerMissing" BeforeTargets="Build" Condition="!Exists('$(_D2SharpWorkerSourcePath)D2Sharp.Worker') AND !Exists('$(_D2SharpWorkerSourcePath)D2Sharp.Worker.dll')">
+    <Warning Text="D2Sharp.Worker executable not found at $(_D2SharpWorkerSourcePath). Process isolation will not be available. Run 'dotnet build' at solution level or build src/D2Sharp.Worker manually." />
+  </Target>
+</Project>

--- a/src/D2Sharp/D2Sharp.targets
+++ b/src/D2Sharp/D2Sharp.targets
@@ -55,8 +55,10 @@
     </Content>
   </ItemGroup>
 
-  <!-- Warn if Worker files are missing (e.g., after dotnet clean with project references) -->
-  <Target Name="WarnIfD2SharpWorkerMissing" BeforeTargets="Build" Condition="!Exists('$(_D2SharpWorkerSourcePath)D2Sharp.Worker') AND !Exists('$(_D2SharpWorkerSourcePath)D2Sharp.Worker.dll')">
-    <Warning Text="D2Sharp.Worker executable not found at $(_D2SharpWorkerSourcePath). Process isolation will not be available. Run 'dotnet build' at solution level or build src/D2Sharp.Worker manually." />
+  <!-- Warn if Worker files are missing (e.g., in NuGet package context or after clean) -->
+  <Target Name="WarnIfD2SharpWorkerMissing"
+          BeforeTargets="Build"
+          Condition="!Exists('$(_D2SharpWorkerSourcePath)D2Sharp.Worker') AND !Exists('$(_D2SharpWorkerSourcePath)D2Sharp.Worker.dll')">
+    <Warning Text="D2Sharp.Worker executable not found. Process isolation will not be available. Run 'dotnet build' at solution level or ensure Worker project is built." />
   </Target>
 </Project>

--- a/src/D2Sharp/Internal/D2WrapperProcessPool.cs
+++ b/src/D2Sharp/Internal/D2WrapperProcessPool.cs
@@ -66,7 +66,11 @@ public class D2WrapperProcessPool : ID2Renderer
 
         if (!File.Exists(_workerPath) && !File.Exists(_workerPath + ".dll"))
         {
-            throw new FileNotFoundException($"Worker executable not found at {_workerPath}");
+            throw new FileNotFoundException(
+                $"Worker executable not found at {_workerPath}. " +
+                "This usually happens after 'dotnet clean' or when building individual projects. " +
+                "Fix: Run 'dotnet build' at the solution level, or build the Worker project first with 'dotnet build src/D2Sharp.Worker'. " +
+                "Alternatively, use D2Renderer.CreateDirect() which doesn't require the worker process.");
         }
 
         _workers = new List<WorkerInstance>();


### PR DESCRIPTION
## Summary

Fixes Windows CI build failure where `d2wrapper.dll` wasn't being copied to dependent projects (IntegrationTests), blocking the v0.4.1 release.

## Root Cause

The static `<None>` item was evaluated at project load time, **before** the `BuildD2Wrapper` target ran:

```xml
<None Include="$(OutputPath)\$(NativeLibName)">
    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
</None>
```

So MSBuild didn't know the file existed yet, and couldn't copy it to dependent projects on Windows.

## Solution

Replace with a dynamic `<Content>` target that runs **after** `BuildD2Wrapper`:

```xml
<Target Name="IncludeNativeLibrary" AfterTargets="BuildD2Wrapper" BeforeTargets="BeforeBuild">
    <ItemGroup>
        <Content Include="$(OutputPath)$(NativeLibName)">
            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
            ...
        </Content>
    </ItemGroup>
</Target>
```

This ensures the file is added to the project **after** it's built, so MSBuild knows about it and can copy it correctly.

## Verification

- ✅ Local clean build succeeds
- ✅ Native library copied to IntegrationTests output
- ✅ No changes to packaging or runtime behavior